### PR TITLE
Drop ValueFormatterTestBase::getFormatterClass

### DIFF
--- a/Interfaces.php
+++ b/Interfaces.php
@@ -15,7 +15,7 @@ if ( defined( 'DataValuesInterfaces_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.2.0' );
+define( 'DATAVALUES_INTERFACES_VERSION', '0.2.0 alpha' );
 
 /**
  * @deprecated

--- a/Interfaces.php
+++ b/Interfaces.php
@@ -15,7 +15,7 @@ if ( defined( 'DataValuesInterfaces_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.1.5' );
+define( 'DATAVALUES_INTERFACES_VERSION', '0.2.0' );
 
 /**
  * @deprecated

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 0.2.0 (alpha)
+
+* Dropped `ValueFormatterTestBase::getFormatterClass`
+* Made `ValueFormatterTestBase::getInstance` abstract
+
 ### 0.1.5 (2015-02-14)
 
 * The options in the `ValueFormatterBase` constructor are now optional

--- a/tests/ValueFormatters/ValueFormatterTestBase.php
+++ b/tests/ValueFormatters/ValueFormatterTestBase.php
@@ -2,6 +2,7 @@
 
 namespace ValueFormatters\Test;
 
+use LogicException;
 use ValueFormatters\FormatterOptions;
 use ValueFormatters\ValueFormatter;
 
@@ -28,24 +29,27 @@ abstract class ValueFormatterTestBase extends \PHPUnit_Framework_TestCase {
 	public abstract function validProvider();
 
 	/**
-	 * Returns the name of the ValueFormatter implementing class.
-	 *
-	 * @since 0.1
+	 * @deprecated since 0.2, override the getInstance method instead.
 	 *
 	 * @return string
 	 */
-	protected abstract function getFormatterClass();
+	protected function getFormatterClass() {
+		throw new LogicException(
+			'ValueFormatterTestBase subclasses either need to override getFormatterClass or getInstance'
+		);
+	}
 
 	/**
 	 * @since 0.1
+	 * @todo Should become abstract when getFormatterClass is removed.
 	 *
-	 * @param FormatterOptions $options
+	 * @param FormatterOptions|null $options
 	 *
 	 * @return ValueFormatter
 	 */
-	protected function getInstance( FormatterOptions $options ) {
+	protected function getInstance( FormatterOptions $options = null ) {
 		$class = $this->getFormatterClass();
-		return new $class( $options );
+		return new $class( $options ?: new FormatterOptions() );
 	}
 
 	/**
@@ -59,11 +63,7 @@ abstract class ValueFormatterTestBase extends \PHPUnit_Framework_TestCase {
 	 * @param ValueFormatter|null $formatter
 	 */
 	public function testValidFormat( $value, $expected, FormatterOptions $options = null, ValueFormatter $formatter = null ) {
-		if ( $options === null ) {
-			$options = new FormatterOptions();
-		}
-
-		if ( is_null( $formatter ) ) {
+		if ( $formatter === null ) {
 			$formatter = $this->getInstance( $options );
 		}
 

--- a/tests/ValueFormatters/ValueFormatterTestBase.php
+++ b/tests/ValueFormatters/ValueFormatterTestBase.php
@@ -2,7 +2,6 @@
 
 namespace ValueFormatters\Test;
 
-use LogicException;
 use ValueFormatters\FormatterOptions;
 use ValueFormatters\ValueFormatter;
 
@@ -29,28 +28,13 @@ abstract class ValueFormatterTestBase extends \PHPUnit_Framework_TestCase {
 	public abstract function validProvider();
 
 	/**
-	 * @deprecated since 0.2, override the getInstance method instead.
-	 *
-	 * @return string
-	 */
-	protected function getFormatterClass() {
-		throw new LogicException(
-			'ValueFormatterTestBase subclasses either need to override getFormatterClass or getInstance'
-		);
-	}
-
-	/**
 	 * @since 0.1
-	 * @todo Should become abstract when getFormatterClass is removed.
 	 *
 	 * @param FormatterOptions|null $options
 	 *
 	 * @return ValueFormatter
 	 */
-	protected function getInstance( FormatterOptions $options = null ) {
-		$class = $this->getFormatterClass();
-		return new $class( $options ?: new FormatterOptions() );
-	}
+	protected abstract function getInstance( FormatterOptions $options = null );
 
 	/**
 	 * @dataProvider validProvider


### PR DESCRIPTION
Similar to https://github.com/DataValues/Common/pull/25:

Please review #9 (commit 1) first, merge it, then rebase this patch and review it separately. Or even better: Please move this component to Gerrit so I can create an actual chain that's actually reviewable?

Also: Why is this base class in Interfaces while the other is in Common?