### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/Interfaces.php
+++ b/Interfaces.php
@@ -10,17 +10,12 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 
-if ( defined( 'DataValuesInterfaces_VERSION' ) ) {
+if ( defined( 'DATAVALUES_INTERFACES_VERSION' ) ) {
 	// Do not initialize more than once.
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.2.0 alpha' );
-
-/**
- * @deprecated
- */
-define( 'DataValuesInterfaces_VERSION', DATAVALUES_INTERFACES_VERSION );
+define( 'DATAVALUES_INTERFACES_VERSION', '1.0.0 alpha' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
-### 0.2.0 (alpha)
+### 1.0.0 (alpha)
 
+* Dropped deprecated `ErrorObject`, use `Error` instead
+* Dropped deprecated `ResultObject`, use `Result` instead
+* Dropped deprecated constant `DataValuesInterfaces_VERSION`, use `DATAVALUES_INTERFACES_VERSION` instead
 * Dropped `ValueFormatterTestBase::getFormatterClass`
 * Made `ValueFormatterTestBase::getInstance` abstract
 * The options in `ValueFormatterTestBase::getInstance` are now optional

--- a/src/ValueValidators/Error.php
+++ b/src/ValueValidators/Error.php
@@ -95,8 +95,3 @@ class Error {
 	}
 
 }
-
-/**
- * @deprecated
- */
-class ErrorObject extends Error {}

--- a/src/ValueValidators/Result.php
+++ b/src/ValueValidators/Result.php
@@ -112,8 +112,3 @@ class Result {
 	}
 
 }
-
-/**
- * @deprecated
- */
-class ResultObject extends Result {}


### PR DESCRIPTION
Same reason as given in https://github.com/DataValues/Common/pull/22#issuecomment-77376750, we should not be in the 0.x range any more.