### PR TITLE
Add missing array type hints

### DIFF
--- a/src/ValueValidators/Error.php
+++ b/src/ValueValidators/Error.php
@@ -30,7 +30,7 @@ class Error {
 	 *
 	 * @return Error
 	 */
-	public static function newError( $text = '', $property = null, $code = 'invalid', $params = array() ) {
+	public static function newError( $text = '', $property = null, $code = 'invalid', array $params = array() ) {
 		return new static( $text, Error::SEVERITY_ERROR, $property, $code, $params );
 	}
 
@@ -43,7 +43,7 @@ class Error {
 	 * @param string      $code
 	 * @param array       $params
 	 */
-	protected function __construct( $text, $severity, $property, $code, $params ) {
+	protected function __construct( $text, $severity, $property, $code, array $params ) {
 		$this->text = $text;
 		$this->severity = $severity;
 		$this->property = $property;

--- a/tests/ValueFormatters/FormatterOptionsTest.php
+++ b/tests/ValueFormatters/FormatterOptionsTest.php
@@ -62,10 +62,6 @@ class FormatterOptionsTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider setOptionProvider
-	 *
-	 * @param FormatterOptions $options
-	 * @param $option
-	 * @param $value
 	 */
 	public function testSetAndGetOption( FormatterOptions $options, $option, $value ) {
 		$options->setOption( $option, $value );

--- a/tests/ValueParsers/ParserOptionsTest.php
+++ b/tests/ValueParsers/ParserOptionsTest.php
@@ -62,10 +62,6 @@ class ParserOptionsTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider setOptionProvider
-	 *
-	 * @param ParserOptions $options
-	 * @param $option
-	 * @param $value
 	 */
 	public function testSetAndGetOption( ParserOptions $options, $option, $value ) {
 		$options->setOption( $option, $value );


### PR DESCRIPTION
I double-checked all usages. The only user of the constructor is the `UniquenessViolation` subclass, which already haves the array type hint.