### PR TITLE
Use `self` instead of `Error`

### DIFF
--- a/src/ValueValidators/Error.php
+++ b/src/ValueValidators/Error.php
@@ -31,7 +31,7 @@ class Error {
 	 * @return Error
 	 */
 	public static function newError( $text = '', $property = null, $code = 'invalid', array $params = array() ) {
-		return new static( $text, Error::SEVERITY_ERROR, $property, $code, $params );
+		return new static( $text, self::SEVERITY_ERROR, $property, $code, $params );
 	}
 
 	/**


### PR DESCRIPTION
HHVM 1.11.0 complains with »Cannot declare class ValueValidators\Error because
the name was implicitly used on line 34; implicit use of names from the HH
namespace can be suppressed by adding an explicit `use' statement earlier in
the current namespace block«.