### PR TITLE
Remove ValueValidator::setOptions from the interface

### DIFF
--- a/Interfaces.php
+++ b/Interfaces.php
@@ -15,4 +15,4 @@ if ( defined( 'DATAVALUES_INTERFACES_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.2.5' );
+define( 'DATAVALUES_INTERFACES_VERSION', '1.0.0 alpha' );

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 1.0.0 (alpha)
+
+* Removed `ValueValidator::setOptions` from the interface
+* Removed `$optionMap` parameter from `ValueValidatorObject::runSubValidator`
+
 ### 0.2.5 (2017-08-09)
 
 * Removed MediaWiki extension credits registration

--- a/src/ValueValidators/ValueValidator.php
+++ b/src/ValueValidators/ValueValidator.php
@@ -23,13 +23,4 @@ interface ValueValidator {
 	 */
 	public function validate( $value );
 
-	/**
-	 * Takes an associative array with options and sets those known to the ValueValidator.
-	 *
-	 * @since 0.1
-	 *
-	 * @param array $options
-	 */
-	public function setOptions( array $options );
-
 }

--- a/src/ValueValidators/ValueValidatorObject.php
+++ b/src/ValueValidators/ValueValidatorObject.php
@@ -150,38 +150,14 @@ abstract class ValueValidatorObject implements ValueValidator {
 
 	/**
 	 * Runs the value through the provided ValueValidator and registers the errors.
-	 * Options of $this can be mapped to those of the passed ValueValidator using
-	 * the $optionMap parameter in which keys are source names and values are target
-	 * names.
 	 *
-	 * @since 0.1
+	 * @since 0.3
 	 *
 	 * @param mixed $value
 	 * @param ValueValidator $validator
 	 * @param string|null $property
-	 * @param array $optionMap
 	 */
-	protected function runSubValidator(
-		$value,
-		ValueValidator $validator,
-		$property = null,
-		array $optionMap = []
-	) {
-		if ( $optionMap !== [] ) {
-			$options = [];
-
-			foreach ( $optionMap as $source => $target ) {
-				if ( array_key_exists( $source, $this->options ) ) {
-					$options[$target] = $this->options[$source];
-				}
-			}
-
-			$validator->setOptions( $options );
-		}
-
-		/**
-		 * @var Error $error
-		 */
+	protected function runSubValidator( $value, ValueValidator $validator, $property = null ) {
 		foreach ( $validator->validate( $value )->getErrors() as $error ) {
 			$this->addError( Error::newError( $error->getText(), $property ) );
 		}


### PR DESCRIPTION
The one and only reason why this method is in the interface can be seen in https://github.com/DataValues/Validators/pull/11. With the change I'm doing in DataValues Validators the method is not called any more. Which means we can do a very convenient update from `"data-values/interfaces": "~0.2.0"` to `"data-values/interfaces": "~0.3.0|~0.2.0"` in that and all other depending components.
