### PR TITLE
Fix non-strict comparison issue in ValueFormatterTestBase

### DIFF
--- a/Interfaces.php
+++ b/Interfaces.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_INTERFACES_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.2.1' );
+define( 'DATAVALUES_INTERFACES_VERSION', '0.2.2' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 0.2.2 (2016-07-14)
+
+* Fixed `ValueFormatterTestBase` not doing strict string comparisons
+
 ### 0.2.1 (2016-01-13)
 
 * Fixed an issue when using this component with HHVM 1.11.0 (see #21).

--- a/tests/ValueFormatters/FormatterOptionsTest.php
+++ b/tests/ValueFormatters/FormatterOptionsTest.php
@@ -25,7 +25,7 @@ class FormatterOptionsTest extends \PHPUnit_Framework_TestCase {
 		$formatterOptions = new FormatterOptions( $options );
 
 		foreach ( $options as $option => $value ) {
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $formatterOptions->getOption( $option ) ),
 				'Option should be set properly'
@@ -105,7 +105,7 @@ class FormatterOptionsTest extends \PHPUnit_Framework_TestCase {
 
 		foreach ( $values as $value ) {
 			$formatterOptions->setOption( $value[0], $value[1] );
-			$this->assertEquals( $value[1], $formatterOptions->getOption( $value[0] ) );
+			$this->assertSame( $value[1], $formatterOptions->getOption( $value[0] ) );
 		}
 	}
 
@@ -163,7 +163,7 @@ class FormatterOptionsTest extends \PHPUnit_Framework_TestCase {
 		foreach ( $options as $option => $value ) {
 			$formatterOptions->defaultOption( $option, 9001 );
 
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $formatterOptions->getOption( $option ) ),
 				'Defaulting a set option should not affect its value'
@@ -180,7 +180,7 @@ class FormatterOptionsTest extends \PHPUnit_Framework_TestCase {
 		foreach ( $defaults as $option => $value ) {
 			$formatterOptions->defaultOption( $option, $value );
 
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $formatterOptions->getOption( $option ) ),
 				'Defaulting a not set option should affect its value'

--- a/tests/ValueFormatters/ValueFormatterTestBase.php
+++ b/tests/ValueFormatters/ValueFormatterTestBase.php
@@ -56,7 +56,7 @@ abstract class ValueFormatterTestBase extends \PHPUnit_Framework_TestCase {
 			$formatter = $this->getInstance( $options );
 		}
 
-		$this->assertEquals( $expected, $formatter->format( $value ) );
+		$this->assertSame( $expected, $formatter->format( $value ) );
 	}
 
 }

--- a/tests/ValueParsers/ParserOptionsTest.php
+++ b/tests/ValueParsers/ParserOptionsTest.php
@@ -25,7 +25,7 @@ class ParserOptionsTest extends \PHPUnit_Framework_TestCase {
 		$parserOptions = new ParserOptions( $options );
 
 		foreach ( $options as $option => $value ) {
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $parserOptions->getOption( $option ) ),
 				'Option should be set properly'
@@ -105,7 +105,7 @@ class ParserOptionsTest extends \PHPUnit_Framework_TestCase {
 
 		foreach ( $values as $value ) {
 			$parserOptions->setOption( $value[0], $value[1] );
-			$this->assertEquals( $value[1], $parserOptions->getOption( $value[0] ) );
+			$this->assertSame( $value[1], $parserOptions->getOption( $value[0] ) );
 		}
 	}
 
@@ -163,7 +163,7 @@ class ParserOptionsTest extends \PHPUnit_Framework_TestCase {
 		foreach ( $options as $option => $value ) {
 			$parserOptions->defaultOption( $option, 9001 );
 
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $parserOptions->getOption( $option ) ),
 				'Defaulting a set option should not affect its value'
@@ -180,7 +180,7 @@ class ParserOptionsTest extends \PHPUnit_Framework_TestCase {
 		foreach ( $defaults as $option => $value ) {
 			$parserOptions->defaultOption( $option, $value );
 
-			$this->assertEquals(
+			$this->assertSame(
 				serialize( $value ),
 				serialize( $parserOptions->getOption( $option ) ),
 				'Defaulting a not set option should affect its value'

--- a/tests/ValueValidators/ErrorTest.php
+++ b/tests/ValueValidators/ErrorTest.php
@@ -53,19 +53,19 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'array', $error->getParameters() );
 
 		if ( count( $args ) > 0 ) {
-			$this->assertEquals( $args[0], $error->getText() );
+			$this->assertSame( $args[0], $error->getText() );
 		}
 
 		if ( count( $args ) > 1 ) {
-			$this->assertEquals( $args[1], $error->getProperty() );
+			$this->assertSame( $args[1], $error->getProperty() );
 		}
 
 		if ( count( $args ) > 2 ) {
-			$this->assertEquals( $args[2], $error->getCode() );
+			$this->assertSame( $args[2], $error->getCode() );
 		}
 
 		if ( count( $args ) > 3 ) {
-			$this->assertEquals( $args[3], $error->getParameters() );
+			$this->assertSame( $args[3], $error->getParameters() );
 		}
 	}
 

--- a/tests/ValueValidators/ResultTest.php
+++ b/tests/ValueValidators/ResultTest.php
@@ -77,7 +77,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase {
 	public function testMerge( $a, $b, $expectedValid, $expectedErrorCount, $message ) {
 		$result = Result::merge( $a, $b );
 
-		$this->assertEquals( $expectedValid, $result->isValid(), $message );
+		$this->assertSame( $expectedValid, $result->isValid(), $message );
 		$this->assertCount( $expectedErrorCount, $result->getErrors(), $message );
 	}
 


### PR DESCRIPTION
Number formatters return strings like "2" and "2.0". `assertEquals` considers these the same, which is just wrong when testing a formatter.

This is critical for https://github.com/DataValues/Number/pull/66.