### PR TITLE
Remove MediaWiki registration and release 0.2.5

### DIFF
--- a/Interfaces.php
+++ b/Interfaces.php
@@ -15,4 +15,4 @@ if ( defined( 'DATAVALUES_INTERFACES_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_INTERFACES_VERSION', '0.2.3' );
+define( 'DATAVALUES_INTERFACES_VERSION', '0.2.5' );

--- a/Interfaces.php
+++ b/Interfaces.php
@@ -16,17 +16,3 @@ if ( defined( 'DATAVALUES_INTERFACES_VERSION' ) ) {
 }
 
 define( 'DATAVALUES_INTERFACES_VERSION', '0.2.3' );
-
-if ( defined( 'MEDIAWIKI' ) ) {
-	$GLOBALS['wgExtensionCredits']['datavalues'][] = [
-		'path' => __DIR__,
-		'name' => 'DataValues Interfaces',
-		'version' => DATAVALUES_INTERFACES_VERSION,
-		'author' => [
-			'[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]',
-		],
-		'url' => 'https://github.com/DataValues/Interfaces',
-		'description' => 'Defines interfaces for ValueParsers, ValueFormatters and ValueValidators',
-		'license-name' => 'GPL-2.0+'
-	];
-}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 0.2.5 (2017-08-09)
+
+* Removed MediaWiki extension credits registration
+
 ### 0.2.4 (2017-08-02)
 
 * Fixed `ValueFormatterTestBase` not being installable via Composer.


### PR DESCRIPTION
MediaWiki shows credits of installed composer libraries, so this isn't necessary.