### PR TITLE
Add `withDefaultOption()` to replace `defaultOption()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ via Github Actions.
 
 ## Release notes
 
+### 1.1.0 (dev)
+
+* Introduced `ParserOptions::withDefaultOption()` and `FormatterOptions::withDefaultOption()`,
+  which return a copy of the options with the default applied;
+  the `defaultOption()` methods, which modify the options in place, are deprecated.
+
 ### 1.0.0 (2021-01-20)
 
 * Updated minimum required PHP version from 5.5.9 to 7.2

--- a/src/ValueFormatters/FormatterOptions.php
+++ b/src/ValueFormatters/FormatterOptions.php
@@ -33,6 +33,30 @@ final class FormatterOptions {
 	}
 
 	/**
+	 * Create and return a copy of these options,
+	 * where the value of an option was set to the provided default
+	 * if it had not been set already.
+	 *
+	 * Example usage:
+	 * ```php
+	 * public function __construct( FormatterOptions $options ) {
+	 *     $this->options = $options
+	 *         ->withDefaultOption( self::OPT_A, 'A' )
+	 *         ->withDefaultOption( self::OPT_B, 'B' );
+	 * }
+	 * ```
+	 *
+	 * @param string $option
+	 * @param mixed $default
+	 * @return self
+	 */
+	public function withDefaultOption( string $option, $default ): self {
+		$options = new self( $this->options );
+		$options->defaultOption( $option, $default );
+		return $options;
+	}
+
+	/**
 	 * Sets the value of the specified option.
 	 *
 	 * @param string $option
@@ -75,6 +99,7 @@ final class FormatterOptions {
 	/**
 	 * Sets the value of an option to the provided default in case the option is not set yet.
 	 *
+	 * @deprecated Use {@link withDefaultOption()} instead.
 	 * @param string $option
 	 * @param mixed $default
 	 */

--- a/src/ValueParsers/ParserOptions.php
+++ b/src/ValueParsers/ParserOptions.php
@@ -34,6 +34,30 @@ final class ParserOptions {
 	}
 
 	/**
+	 * Create and return a copy of these options,
+	 * where the value of an option was set to the provided default
+	 * if it had not been set already.
+	 *
+	 * Example usage:
+	 * ```php
+	 * public function __construct( ParserOptions $options ) {
+	 *     $this->options = $options
+	 *         ->withDefaultOption( self::OPT_A, 'A' )
+	 *         ->withDefaultOption( self::OPT_B, 'B' );
+	 * }
+	 * ```
+	 *
+	 * @param string $option
+	 * @param mixed $default
+	 * @return self
+	 */
+	public function withDefaultOption( string $option, $default ): self {
+		$options = new self( $this->options );
+		$options->defaultOption( $option, $default );
+		return $options;
+	}
+
+	/**
 	 * Sets the value of the specified option.
 	 *
 	 * @param string $option
@@ -76,6 +100,7 @@ final class ParserOptions {
 	/**
 	 * Sets the value of an option to the provided default in case the option is not set yet.
 	 *
+	 * @deprecated Use {@link withDefaultOption()} instead.
 	 * @param string $option
 	 * @param mixed $default
 	 */

--- a/tests/ValueFormatters/FormatterOptionsTest.php
+++ b/tests/ValueFormatters/FormatterOptionsTest.php
@@ -191,4 +191,23 @@ class FormatterOptionsTest extends TestCase {
 		}
 	}
 
+	public function testWithDefaultOption() {
+		$originalOptions = new FormatterOptions( [ 'foo' => 'foo' ] );
+
+		$newOptions = $originalOptions
+			->withDefaultOption( 'foo', 'FOO' )
+			->withDefaultOption( 'bar', 'BAR' );
+
+		$this->assertNotSame( $originalOptions, $newOptions,
+			'should be a fresh instance' );
+		$this->assertSame( 'foo', $originalOptions->getOption( 'foo' ),
+			'original options should have same non-default option' );
+		$this->assertFalse( $originalOptions->hasOption( 'bar' ),
+			'original options should not have default option' );
+		$this->assertSame( 'foo', $newOptions->getOption( 'foo' ),
+			'new options should have same non-default option' );
+		$this->assertSame( 'BAR', $newOptions->getOption( 'bar' ),
+			'new options should have default option' );
+	}
+
 }

--- a/tests/ValueParsers/ParserOptionsTest.php
+++ b/tests/ValueParsers/ParserOptionsTest.php
@@ -191,4 +191,23 @@ class ParserOptionsTest extends TestCase {
 		}
 	}
 
+	public function testWithDefaultOption() {
+		$originalOptions = new ParserOptions( [ 'foo' => 'foo' ] );
+
+		$newOptions = $originalOptions
+			->withDefaultOption( 'foo', 'FOO' )
+			->withDefaultOption( 'bar', 'BAR' );
+
+		$this->assertNotSame( $originalOptions, $newOptions,
+			'should be a fresh instance' );
+		$this->assertSame( 'foo', $originalOptions->getOption( 'foo' ),
+			'original options should have same non-default option' );
+		$this->assertFalse( $originalOptions->hasOption( 'bar' ),
+			'original options should not have default option' );
+		$this->assertSame( 'foo', $newOptions->getOption( 'foo' ),
+			'new options should have same non-default option' );
+		$this->assertSame( 'BAR', $newOptions->getOption( 'bar' ),
+			'new options should have default option' );
+	}
+
 }

--- a/tests/ValueParsers/ParserOptionsTest.php
+++ b/tests/ValueParsers/ParserOptionsTest.php
@@ -45,7 +45,7 @@ class ParserOptionsTest extends TestCase {
 			42 => [ 'o_O', false, null, '42' => 42, [] ]
 		];
 
-		$this->expectException( 'Exception' );
+		$this->expectException( \Exception::class );
 
 		new ParserOptions( $options );
 	}
@@ -117,11 +117,11 @@ class ParserOptionsTest extends TestCase {
 	 */
 	public function testGetOption( $nonExistingOption ) {
 		$this->assertTrue( true );
-		$formatterOptions = new ParserOptions( [ 'foo' => 'bar' ] );
+		$parserOptions = new ParserOptions( [ 'foo' => 'bar' ] );
 
 		$this->expectException( 'InvalidArgumentException' );
 
-		$formatterOptions->getOption( $nonExistingOption );
+		$parserOptions->getOption( $nonExistingOption );
 	}
 
 	public function nonExistingOptionsProvider() {


### PR DESCRIPTION
Passing the same mutable options instance around all over the place, with various parts of the code adding different defaults to it, is a recipe for confusion and bugs. Discourage it by introducing a new method that has cloning built into its interface.

Partially motivated by [Construct parsers with a copy of ParserOptions](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/620381).