### PR TITLE
Bump actions/checkout fetch-depth to 2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
The default of 1 (only HEAD, no parents) is not enough for Scrutinizer, it seems. Problem witnessed in #59.

----

Compare https://github.com/DataValues/Common/pull/97.