### PR TITLE
Add MismatchingOptionTypeException to handle bad options

### DIFF
--- a/src/ValueFormatters/FormatterOptions.php
+++ b/src/ValueFormatters/FormatterOptions.php
@@ -90,6 +90,29 @@ final class FormatterOptions {
 	}
 
 	/**
+	 * Returns the value of the specified option. If the option is not set,
+	 * an OutOfBoundsException is thrown. If the option exists and is set
+	 * but the value is not a string, a MismatchingOptionTypeException is thrown.
+	 *
+	 * @param string $option
+	 *
+	 * @throws OutOfBoundsException
+	 * @throws MismatchingOptionTypeException
+	 * @return string
+	 */
+	public function getStringOption( string $option ) {
+		$result = $this->getOption( $option );
+		if ( gettype( $result ) !== "string" ) {
+			throw new MismatchingOptionTypeException(
+				"string",
+				gettype( $result ),
+				"Expected string value for option '$option' but found " . gettype( $result )
+			);
+		}
+		return $result;
+	}
+
+	/**
 	 * Returns if the specified option is set or not.
 	 */
 	public function hasOption( string $option ): bool {

--- a/src/ValueFormatters/MismatchingOptionTypeException.php
+++ b/src/ValueFormatters/MismatchingOptionTypeException.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ValueFormatters;
+
+use Exception;
+
+/**
+ * @since 1.1.1
+ *
+ * @license GPL-2.0-or-later
+ * @author Arthur Taylor
+ */
+class MismatchingOptionTypeException extends \InvalidArgumentException {
+
+	/**
+	 * @var string
+	 */
+	private $expectedType;
+
+	/**
+	 * @var string
+	 */
+	private $optionType;
+
+	/**
+	 * @param string $expectedType
+	 * @param string $optionType
+	 * @param string $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct(
+		$expectedType,
+		$optionType,
+		$message = '',
+		Exception $previous = null
+	) {
+		$this->expectedType = $expectedType;
+		$this->optionType = $optionType;
+
+		if ( $message === '' ) {
+			$message = 'Option type "' . $optionType . '" does not match expected "'
+				. $expectedType . '"';
+		}
+
+		parent::__construct( $message, 0, $previous );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getExpectedType() {
+		return $this->expectedType;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getOptionType() {
+		return $this->optionType;
+	}
+
+}

--- a/tests/ValueFormatters/FormatterOptionsTest.php
+++ b/tests/ValueFormatters/FormatterOptionsTest.php
@@ -6,6 +6,7 @@ namespace ValueFormatters\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ValueFormatters\FormatterOptions;
+use ValueFormatters\MismatchingOptionTypeException;
 
 /**
  * @covers \ValueFormatters\FormatterOptions
@@ -122,6 +123,34 @@ class FormatterOptionsTest extends TestCase {
 		$this->expectException( 'OutOfBoundsException' );
 
 		$formatterOptions->getOption( $nonExistingOption );
+	}
+
+	public function testGetStringOption() {
+		$formatterOptions = new FormatterOptions( [ 'string' => 'option', 'int' => 3 ] );
+		$this->assertEquals( 'option', $formatterOptions->getStringOption( 'string' ) );
+
+		$this->expectException( MismatchingOptionTypeException::class );
+		$this->expectExceptionMessage( "Expected string value for option 'int' but found integer" );
+
+		$formatterOptions->getStringOption( 'int' );
+	}
+
+	public function testGetNonExistentStringOption() {
+		$formatterOptions = new FormatterOptions( [ 'string' => 'option', 'int' => 3 ] );
+
+		$this->expectException( \OutOfBoundsException::class );
+		$this->expectExceptionMessage( "Option 'test' has not been set so cannot be obtained" );
+
+		$formatterOptions->getStringOption( 'test' );
+	}
+
+	public function testGetNullStringOption() {
+		$formatterOptions = new FormatterOptions( [ 'test' => null ] );
+
+		$this->expectException( MismatchingOptionTypeException::class );
+		$this->expectExceptionMessage( "Expected string value for option 'test' but found NULL" );
+
+		$formatterOptions->getStringOption( 'test' );
 	}
 
 	public function nonExistingOptionsProvider() {

--- a/tests/ValueFormatters/MismatchingOptionTypeExceptionTest.php
+++ b/tests/ValueFormatters/MismatchingOptionTypeExceptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ValueFormatters;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \ValueFormatters\MismatchingOptionTypeException
+ *
+ * @group ValueFormatters
+ * @group DataValueExtensions
+ *
+ * @license GPL-2.0-or-later
+ * @author Arthur Taylor
+ */
+class MismatchingOptionTypeExceptionTest extends TestCase {
+
+	/**
+	 * @dataProvider constructorProvider
+	 */
+	public function testConstructorWithRequiredArguments( $expectedType, $actualType ) {
+		$exception = new MismatchingOptionTypeException( $expectedType, $actualType );
+
+		$this->assertSame( $expectedType, $exception->getExpectedType() );
+		$this->assertSame( $actualType, $exception->getOptionType() );
+		$this->assertSame(
+			"Option type \"$actualType\" does not match expected \"$expectedType\"",
+			$exception->getMessage()
+		);
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	/**
+	 * @dataProvider constructorProvider
+	 */
+	public function testConstructorWithAllArguments( $expectedType, $actualType ) {
+		$message = 'Onoez! an error!';
+		$previous = new Exception( 'Onoez!' );
+
+		$exception = new MismatchingOptionTypeException(
+			$expectedType,
+			$actualType,
+			$message,
+			$previous
+		);
+
+		$this->assertSame( $expectedType, $exception->getExpectedType() );
+		$this->assertSame( $actualType, $exception->getOptionType() );
+		$this->assertSame( $message, $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
+	}
+
+	public function constructorProvider() {
+		return [
+			[ 'string', 'time' ],
+			[ 'globecoordinate', 'string' ]
+		];
+	}
+
+}


### PR DESCRIPTION
The DataValues Formatters can throw raw TypeErrors if Options are configured with
incorrectly typed values. To improve the handling of these errors in our code, it would
help if we can get a more specific error. This PR introduces a
MismatchingOptionTypeException and a strict string getter for retrieving options.
A follow-up change to DataValues/Geo uses the strict getter to better handle
misconfiguration of options.

Bug: [T323778](https://phabricator.wikimedia.org/T323778)