### PR TITLE
Upgrade mediawiki-codesniffer to latest version (45.0.0)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.2'
-          - '7.3'
           - '7.4'
           - '8.0'
 

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.5",
-		"mediawiki/mediawiki-codesniffer": "^34",
+		"mediawiki/mediawiki-codesniffer": "^45",
 		"ockcyp/covers-validator": "~1.0",
 		"phpstan/phpstan": "^0.12.68",
 		"phpmd/phpmd": "^2.9.1"
@@ -51,5 +51,10 @@
 			"@test",
 			"@cs"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,4 +12,5 @@
 	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 	<rule ref="Generic.Metrics.NestingLevel" />
 	<rule ref="Squiz.Operators.ValidLogicalOperators" />
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
 </ruleset>

--- a/src/ValueFormatters/FormatterOptions.php
+++ b/src/ValueFormatters/FormatterOptions.php
@@ -9,7 +9,7 @@ use OutOfBoundsException;
 use RuntimeException;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 final class FormatterOptions {

--- a/src/ValueFormatters/FormattingException.php
+++ b/src/ValueFormatters/FormattingException.php
@@ -7,7 +7,7 @@ namespace ValueFormatters;
 use RuntimeException;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FormattingException extends RuntimeException {

--- a/src/ValueFormatters/ValueFormatter.php
+++ b/src/ValueFormatters/ValueFormatter.php
@@ -8,7 +8,7 @@ namespace ValueFormatters;
  * Interface for value formatters, typically (but not limited to) expecting a DataValue object and
  * returning a string.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface ValueFormatter {
@@ -17,7 +17,7 @@ interface ValueFormatter {
 	 * Identifier for the option that holds the code of the language in which the formatter should
 	 * operate.
 	 */
-	const OPT_LANG = 'lang';
+	public const OPT_LANG = 'lang';
 
 	/**
 	 * @param mixed $value

--- a/src/ValueParsers/ParseException.php
+++ b/src/ValueParsers/ParseException.php
@@ -7,7 +7,7 @@ namespace ValueParsers;
 use RuntimeException;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ParseException extends RuntimeException {
@@ -23,11 +23,11 @@ class ParseException extends RuntimeException {
 	private $rawValue;
 
 	/**
-	 * @param string $message        A plain english message describing the error
+	 * @param string $message A plain english message describing the error
 	 * @param string|null $rawValue The raw value that failed to be parsed.
 	 * @param string|null $expectedFormat An identifier for the format the raw value did not match
 	 */
-	public function __construct( string $message, string $rawValue = null, string $expectedFormat = null ) {
+	public function __construct( string $message, ?string $rawValue = null, ?string $expectedFormat = null ) {
 		parent::__construct( $message );
 		$this->expectedFormat = $expectedFormat;
 		$this->rawValue = $rawValue;

--- a/src/ValueParsers/ParserOptions.php
+++ b/src/ValueParsers/ParserOptions.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 final class ParserOptions {

--- a/src/ValueParsers/ValueParser.php
+++ b/src/ValueParsers/ValueParser.php
@@ -8,7 +8,7 @@ namespace ValueParsers;
  * Interface for value parsers, typically (but not limited to) expecting a string and returning a
  * DataValue object.
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface ValueParser {

--- a/src/ValueValidators/Error.php
+++ b/src/ValueValidators/Error.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace ValueValidators;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class Error {
@@ -13,14 +13,13 @@ class Error {
 	public const SEVERITY_ERROR = 9;
 	public const SEVERITY_WARNING = 4;
 
-	private $text;
-	private $severity;
-	private $property;
+	private string $text;
+	private int $severity;
+	private ?string $property;
+	private string $code;
+	private array $params;
 
-	private $code;
-	private $params;
-
-	public static function newError( string $text = '', string $property = null, string $code = 'invalid', array $params = [] ): self {
+	public static function newError( string $text = '', ?string $property = null, string $code = 'invalid', array $params = [] ): self {
 		return new self( $text, self::SEVERITY_ERROR, $property, $code, $params );
 	}
 
@@ -37,7 +36,7 @@ class Error {
 	}
 
 	/**
-	 * @return integer, element of the ValueValidatorError::SEVERITY_ enum
+	 * @return int element of the ValueValidatorError::SEVERITY_ enum
 	 */
 	public function getSeverity(): int {
 		return $this->severity;

--- a/src/ValueValidators/Result.php
+++ b/src/ValueValidators/Result.php
@@ -5,13 +5,13 @@ declare( strict_types = 1 );
 namespace ValueValidators;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 final class Result {
 
-	private $isValid;
-	private $errors;
+	private bool $isValid;
+	private array $errors;
 
 	/**
 	 * @return self

--- a/src/ValueValidators/ValueValidator.php
+++ b/src/ValueValidators/ValueValidator.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace ValueValidators;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface ValueValidator {

--- a/tests/ValueFormatters/FormatterOptionsTest.php
+++ b/tests/ValueFormatters/FormatterOptionsTest.php
@@ -13,7 +13,7 @@ use ValueFormatters\FormatterOptions;
  * @group ValueFormatters
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FormatterOptionsTest extends TestCase {

--- a/tests/ValueParsers/ParserOptionsTest.php
+++ b/tests/ValueParsers/ParserOptionsTest.php
@@ -13,7 +13,7 @@ use ValueParsers\ParserOptions;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ParserOptionsTest extends TestCase {

--- a/tests/ValueValidators/ErrorTest.php
+++ b/tests/ValueValidators/ErrorTest.php
@@ -13,7 +13,7 @@ use ValueValidators\Error;
  * @group ValueValidators
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ErrorTest extends TestCase {
@@ -49,7 +49,7 @@ class ErrorTest extends TestCase {
 		 */
 		$this->assertInstanceOf( 'ValueValidators\Error', $error );
 
-		$this->assertTrue( is_string( $error->getProperty() ) || is_null( $error->getProperty() ) );
+		$this->assertTrue( is_string( $error->getProperty() ) || $error->getProperty() === null );
 
 		if ( count( $args ) > 0 ) {
 			$this->assertSame( $args[0], $error->getText() );

--- a/tests/ValueValidators/ResultTest.php
+++ b/tests/ValueValidators/ResultTest.php
@@ -14,7 +14,7 @@ use ValueValidators\Result;
  * @group ValueValidators
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class ResultTest extends TestCase {
@@ -23,7 +23,7 @@ class ResultTest extends TestCase {
 		$result = Result::newSuccess();
 
 		$this->assertTrue( $result->isValid() );
-		$this->assertEmpty( $result->getErrors() );
+		$this->assertCount( 0, $result->getErrors() );
 	}
 
 	public function testNewError() {


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. If the code aims to comply with Mediawiki style guidelines, it makes sense that it continues to comply at current versions of the rules.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Resolves #62

Bug: T379481